### PR TITLE
Refactor classification task to use dataset folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Fingerprint Matching Code
+
+This repository provides utilities for fingerprint matching and a simple classification baseline.
+
+## Dataset Layout
+- Images: `dataset/Synthetic/R1` – `R5` with `.jpg` files.
+- Keypoints: `.tsv` files next to each image containing `x` and `y` columns.
+  Each keypoint entry is given a unique label combining the folder, file name
+  and its index so labels do not collide across images.
+
+## Classification Baseline
+The classification task reuses the same dataset structure. Genuine pairs are created by duplicating a single image and applying independent augmentations. Imposter pairs come from different fingers and use a zero permutation matrix. The loader handles augmentation internally.

--- a/src/benchmark.py
+++ b/src/benchmark.py
@@ -131,11 +131,10 @@ class L3SFV2AugmentedBenchmark(Benchmark):
 
         pairs = []
 
-        # Genuine matches: all unique pairs of images from the same finger
-        for fid, id_list in groups.items():
-            if len(id_list) < 2:
-                continue
-            pairs.extend(itertools.combinations(id_list, 2))
+        # Genuine matches: pair each image with itself so two augmented copies
+        for id_list in groups.values():
+            for img_id in id_list:
+                pairs.append((img_id, img_id))
 
         # Imposter matches: one representative from each finger paired with the
         # representative of every other finger


### PR DESCRIPTION
## Summary
- simplify dataset loader so classification uses the same dataset directory as matching
- compute bounding boxes consistently
- generate classification pairs by pairing each image with itself and produce cross-finger imposters
- augment images inside `get_pair_classify` and return zero permutation matrix for imposters
- document the classification baseline
- ensure pore labels are unique across images
